### PR TITLE
Add support for /tmp/shutdown_in_progress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,27 @@
 CC=gcc
 
 execifup:
-	$(CC) -static -o execifup execifup.c
+	$(CC) -Wall -static -o execifup execifup.c
 
 dynamic:
-	$(CC) -o execifup execifup.c
+	$(CC) -Wall -o execifup execifup.c
 
-test: execifup
+test: execifup cleantest
 	LOG_DEBUG=1 ./execifup 60 "true" 2>&1 | grep DEBUG: || (echo "test fail: debug logging is not working" ; exit 1)
 	./execifup 99999 "false" "true" || (echo "test fail: should have returned 0" ; exit 1)
 	(./execifup 99999 "false" "false" && (echo "test fail: should have returned 1" ; exit 1) ; exit 0)
 	./execifup 0 "true" || (echo "test fail: should have returned 0" ; exit 1)
 	(./execifup 0 "false" && (echo "test fail: should have returned 1" ; exit 1) ; exit 0)
-	@echo "all tests pass"	
+	SHELL=/bin/bash ./execifup 0 'echo $$BASH_VERSION' | grep '[0-9]' || (echo "test fail: custom SHELL is not working"; exit 1)
+	touch /tmp/shutdown_in_progress && ./execifup 0 "false" || (echo "test fail: shutdown check is not working"; exit 1)
+	touch /tmp/shutdown_in_progress && IGNORE_SHUTDOWN_FILE=1 ./execifup 0 "true" || (echo "test fail: ignore shutdown is not working"; exit 1)
+	@echo "** all tests pass **"
 
 .PHONY: clean
 
 clean:
 	rm -f execifup core
+
+cleantest:
+	rm -f /tmp/shutdown_in_progress
+

--- a/execifup.c
+++ b/execifup.c
@@ -1,21 +1,26 @@
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
+#include <libgen.h>
 #include <limits.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <sys/sysinfo.h>
 
 #define LOG_DEBUG(_fmt, ...)            \
 ({                                      \
   if (getenv("LOG_DEBUG") != NULL) {    \
     fprintf(stderr, "DEBUG: ");         \
-    fprintf(stderr, _fmt, __VA_ARGS__); \
+    fprintf(stderr, _fmt, ##__VA_ARGS__); \
   }                                     \
 })
 
 void usage(char *argv0)
 {
-  fprintf(stderr, "usage: %s <n_secs> \"<cmd_if_up_for_n_secs>\" \"<cmd_if_not_up_for_n_secs>\"\n", argv0);
+  fprintf(stderr, "usage: %s <n_secs> \"<cmd_if_up_for_n_secs>\" \"[cmd_if_not_up_for_n_secs]\"\n", argv0);
   fprintf(stderr, "\n");
   fprintf(stderr, " Run commands based on machine uptime.\n");
   fprintf(stderr, "\n");
@@ -23,9 +28,12 @@ void usage(char *argv0)
   fprintf(stderr, " machine or container is starting up.\n");
   fprintf(stderr, "\n");
   fprintf(stderr, "\n");
-  fprintf(stderr, " n_secs                    number of seconds machine must be up for\n");
-  fprintf(stderr, " cmd_if_up_for_n_secs      command to run if the machine has been up n seconds\n"); 
-  fprintf(stderr, " cmd_if_not_up_for_n_secs  command to run if the machine has not yet been up n seconds\n"); 
+  fprintf(stderr, " n_secs                    <required>  number of seconds machine must be up for\n");
+  fprintf(stderr, " cmd_if_up_for_n_secs      <required>  command to run if the machine has been up n seconds\n"); 
+  fprintf(stderr, " cmd_if_not_up_for_n_secs  [optional]  command to run if the machine has not yet been up n seconds\n"); 
+  fprintf(stderr, "\n");
+  fprintf(stderr, "If the file /tmp/shutdown_in_progress exists, assume there is no need to run any commands, and 0 is returned.\n");
+  fprintf(stderr, "You can turn off this behavior by setting the environment variable IGNORE_SHUTDOWN_FILE\n");
   fprintf(stderr, "\n");
   fprintf(stderr, "examples:\n");
   fprintf(stderr, " %s 60 \"(curl localhost/healthz || echo 'ERROR: healthcheck failed')\" &>/proc/1/fd/1\n", argv0);
@@ -38,13 +46,29 @@ void usage(char *argv0)
   fprintf(stderr, " healthcheck is failing, log an INFO message.  This allows you to set up logging rules that ignore INFO healthcheck\n");
   fprintf(stderr, " failures.\n");
   fprintf(stderr, "\n");
+  fprintf(stderr, " LOG_DEBUG=1 SHELL=/bin/bash %s 60 \"(curl localhost/healthz || echo 'ERROR: healthcheck failed')\" &>/proc/1/fd/1\n", argv0);
+  fprintf(stderr, " Same example as above, but with debug logging enabled, and using bash as the shell instead of the default \"/bin/sh\"\n");
+  fprintf(stderr, "\n");
+  fprintf(stderr, "\n");
   exit(1);
+}
+
+bool shutdown_in_progress()
+{
+  struct stat buf;
+
+  return (stat("/tmp/shutdown_in_progress", &buf) == 0);
 }
 
 int main(int argc, char *argv[], char *envp[])
 {
   if (argc < 3) {
     usage(argv[0]);
+  }
+
+  if (getenv("IGNORE_SHUTDOWN_FILE") == NULL && shutdown_in_progress()) {
+    LOG_DEBUG("file /tmp/shutdown_in_progress found, exiting 0\n");
+    exit(0);
   }
 
   char *ssecs = argv[1];
@@ -72,15 +96,32 @@ int main(int argc, char *argv[], char *envp[])
   LOG_DEBUG("cmd_if_up=%s\n", cmd_if_up);
   LOG_DEBUG("cmd_if_not_up=%s\n", cmd_if_not_up);
 
+  char *shell = "/bin/sh";
+  char *shell_argv0 = "sh";
+  char *tmp_shell = NULL;
+  if ((tmp_shell = getenv("SHELL")) != NULL) {
+      if ((shell = strdup(tmp_shell)) == NULL) {
+          perror("shell = strdup(tmp_shell)");
+          exit(96);
+      }
+      char *dup_shell = NULL;
+      if ((dup_shell = strdup(tmp_shell)) == NULL) {
+          perror("dup_shell = strdup(tmp_shell)");
+          exit(97);
+      }
+      shell_argv0 = basename(dup_shell);
+      LOG_DEBUG("custom shell requested, set shell=\"%s\", shell_argv0=\"%s\"\n", shell, shell_argv0);
+  }
+
   if (si.uptime > secs) {
     LOG_DEBUG("machine has been up at least %ld seconds (actually up %ld secs)\n", secs, si.uptime);
-    LOG_DEBUG("executing \"%s\"\n", cmd_if_up);
-    execle("/bin/sh", "sh", "-c", cmd_if_up, (char *)0, envp);
+    LOG_DEBUG("executing %s -c \"%s\"\n", shell, cmd_if_up);
+    execle(shell, shell_argv0, "-c", cmd_if_up, (char *)0, envp);
   } else {
     LOG_DEBUG("machine has NOT been up at least %ld seconds (actually up %ld secs)\n", secs, si.uptime);
     if (cmd_if_not_up != NULL) {
-      LOG_DEBUG("executing \"%s\"\n", cmd_if_not_up);
-      execle("/bin/sh", "sh", "-c", cmd_if_not_up, (char *)0, envp);
+      LOG_DEBUG("executing %s -c \"%s\"\n", shell, cmd_if_not_up);
+      execle(shell, shell_argv0, "-c", cmd_if_not_up, (char *)0, envp);
     }
   }
 


### PR DESCRIPTION
If the file `/tmp/shutdown_in_progress` exists, just exit 0.  

This can be disabled by setting the env var `IGNORE_SHUTDOWN_FILE` to something (does not matter what you set it to).